### PR TITLE
UNIX Compatibility 2: Electric Boogaloo

### DIFF
--- a/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
+++ b/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
@@ -470,8 +470,8 @@ public class JMpqEditor implements AutoCloseable {
         }
         if (hasFile("(listfile)") && listFile != null) {
             for (String s : listFile.getFiles()) {
-                log.debug("extracting: " + s);
-                File temp = new File(dest.getAbsolutePath() + dest.separator + s);
+                log.debug("extracting: " + (dest.separatorChar == '\\' ? s : s.replace("\\", dest.separator)));
+                File temp = new File(dest.getAbsolutePath() + dest.separator + (dest.separatorChar == '\\' ? s : s.replace("\\", dest.separator)));
                 temp.getParentFile().mkdirs();
                 if (hasFile(s)) {
                     // Prevent exception due to nonexistent listfile entries


### PR DESCRIPTION
I definitely did not fully test my last commit,
so this commit resolves the issue with the
extractAllFiles() method on UNIX-based
filesystems.