### PR TITLE
Normalize file names and prevent duplicates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
 
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
  - chmod +x gradlew

--- a/src/test/java/systems/crigges/jmpq3test/MpqTests.java
+++ b/src/test/java/systems/crigges/jmpq3test/MpqTests.java
@@ -366,7 +366,6 @@ public class MpqTests {
             String inName = file.toString().substring(file.toString().lastIndexOf(resourceDir) + resourceDir.length() + File.separator.length());
 
             mpqEditor.insertFile(inName, file, false);
-            mpqEditor.insertFile(inName, file, false);
         }
 
         mpqEditor.close();


### PR DESCRIPTION
`inserts` will now throw an IllegalArgumentException if the file already exists in the archive
`delete` now removes the file also from "toBeAdded" files
