### PR TITLE
Allow usage of external Listfile to rebuild MPQ.

### DIFF
--- a/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
+++ b/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
@@ -21,6 +21,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.*;
 import java.util.*;
+import java.util.function.Predicate;
 
 import static systems.crigges.jmpq3.MpqFile.*;
 
@@ -227,11 +228,25 @@ public class JMpqEditor implements AutoCloseable {
             // Read and apply listfile
             listFile = new Listfile(Files.readAllBytes(externalListfilePath.toPath()));
             checkListfileEntries();
+            removeMissingFiles();
             // Operation succeeded and added a listfile so we can now write properly.
             canWrite = true;
         } catch (Exception ex) {
             log.warn("Could not apply external listfile: " + externalListfilePath.getAbsolutePath());
             canWrite = false;
+        }
+    }
+
+    /**
+     * Removes files from the listfile if they aren't
+     * actually in the map.
+     */
+    private void removeMissingFiles() {
+        Iterator<String> it = listFile.getFiles().iterator();
+        while(it.hasNext()) {
+            if(!hasFile(it.next())) {
+                it.remove();
+            }
         }
     }
 

--- a/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
+++ b/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
@@ -21,7 +21,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.*;
 import java.util.*;
-import java.util.function.Predicate;
 
 import static systems.crigges.jmpq3.MpqFile.*;
 

--- a/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
+++ b/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
@@ -230,26 +230,12 @@ public class JMpqEditor implements AutoCloseable {
             // Read and apply listfile
             listFile = new Listfile(Files.readAllBytes(externalListfilePath.toPath()));
             checkListfileEntries();
-            removeMissingFiles();
             // Operation succeeded and added a listfile so we can now write properly.
             // (as long as it wasn't read-only to begin with)
             canWrite = !openedAsReadOnly;
         } catch (Exception ex) {
             log.warn("Could not apply external listfile: " + externalListfilePath.getAbsolutePath());
             // The value of canWrite is not changed intentionally
-        }
-    }
-
-    /**
-     * Removes files from the listfile if they aren't
-     * actually in the map.
-     */
-    private void removeMissingFiles() {
-        Iterator<String> it = listFile.getFiles().iterator();
-        while(it.hasNext()) {
-            if(!hasFile(it.next())) {
-                it.remove();
-            }
         }
     }
 

--- a/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
+++ b/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
@@ -120,6 +120,8 @@ public class JMpqEditor implements AutoCloseable {
 
     /** If write operations are supported on the archive. */
     private boolean canWrite;
+    /** If the archive was originally read-only */
+    private boolean openedAsReadOnly;
 
     /**
      * Creates a new MPQ editor for the MPQ file at the specified path.
@@ -138,6 +140,7 @@ public class JMpqEditor implements AutoCloseable {
     public JMpqEditor(Path mpqArchive, MPQOpenOption... openOptions) throws JMpqException {
         // process open options
         canWrite = !Arrays.asList(openOptions).contains(MPQOpenOption.READ_ONLY);
+        openedAsReadOnly = !canWrite;
         legacyCompatibility = Arrays.asList(openOptions).contains(MPQOpenOption.FORCE_V0);
         log.debug(mpqArchive.toString());
         try {
@@ -229,10 +232,11 @@ public class JMpqEditor implements AutoCloseable {
             checkListfileEntries();
             removeMissingFiles();
             // Operation succeeded and added a listfile so we can now write properly.
-            canWrite = true;
+            // (as long as it wasn't read-only to begin with)
+            canWrite = !openedAsReadOnly;
         } catch (Exception ex) {
             log.warn("Could not apply external listfile: " + externalListfilePath.getAbsolutePath());
-            canWrite = false;
+            // The value of canWrite is not changed intentionally
         }
     }
 

--- a/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
+++ b/src/main/java/systems/crigges/jmpq3/JMpqEditor.java
@@ -224,12 +224,8 @@ public class JMpqEditor implements AutoCloseable {
             return;
         }
         try {
-            // Copy the user's file to our temp directory
-            File tempFile = File.createTempFile("list", "file", JMpqEditor.tempDir);
-            tempFile.deleteOnExit();
-            Files.copy(externalListfilePath.toPath(), tempFile.toPath());
             // Read and apply listfile
-            listFile = new Listfile(Files.readAllBytes(tempFile.toPath()));
+            listFile = new Listfile(Files.readAllBytes(externalListfilePath.toPath()));
             checkListfileEntries();
             // Operation succeeded and added a listfile so we can now write properly.
             canWrite = true;

--- a/src/test/java/systems/crigges/jmpq3test/MpqTests.java
+++ b/src/test/java/systems/crigges/jmpq3test/MpqTests.java
@@ -20,8 +20,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 
-import static systems.crigges.jmpq3.HashTable.calculateFileKey;
-
 /**
  * Created by Frotty on 06.03.2017.
  */
@@ -134,6 +132,22 @@ public class MpqTests {
             }
             mpqEditor.close(false, false, false);
         }
+    }
+
+    @Test
+    public void testExternalListfile() throws Exception {
+        File mpq = getFile("mpqs/normalMap.w3x");
+        File listFile = getFile("normalMap.w3x");
+        JMpqEditor mpqEditor = new JMpqEditor(mpq, MPQOpenOption.FORCE_V0);
+        if(mpqEditor.isCanWrite()) {
+            mpqEditor.deleteFile("(listfile)");
+        }
+        mpqEditor.setExternalListfile(listFile);
+        Assert.assertTrue(mpqEditor.getListfileEntries().contains("scripts\\war3map.j"));
+        Assert.assertTrue(mpqEditor.getListfileEntries().contains("war3map.j"));
+        Assert.assertTrue(mpqEditor.getListfileEntries().contains("war3map.w3u"));
+        Assert.assertTrue(mpqEditor.getListfileEntries().contains("war3map.w3a"));
+        Assert.assertTrue(mpqEditor.getListfileEntries().contains("customFile.j"));
     }
 
     @Test

--- a/src/test/java/systems/crigges/jmpq3test/MpqTests.java
+++ b/src/test/java/systems/crigges/jmpq3test/MpqTests.java
@@ -137,7 +137,7 @@ public class MpqTests {
     @Test
     public void testExternalListfile() throws Exception {
         File mpq = getFile("mpqs/normalMap.w3x");
-        File listFile = getFile("normalMap.w3x");
+        File listFile = getFile("listfile.txt");
         JMpqEditor mpqEditor = new JMpqEditor(mpq, MPQOpenOption.FORCE_V0);
         if(mpqEditor.isCanWrite()) {
             mpqEditor.deleteFile("(listfile)");

--- a/src/test/java/systems/crigges/jmpq3test/MpqTests.java
+++ b/src/test/java/systems/crigges/jmpq3test/MpqTests.java
@@ -143,11 +143,7 @@ public class MpqTests {
             mpqEditor.deleteFile("(listfile)");
         }
         mpqEditor.setExternalListfile(listFile);
-        Assert.assertTrue(mpqEditor.getListfileEntries().contains("scripts\\war3map.j"));
-        Assert.assertTrue(mpqEditor.getListfileEntries().contains("war3map.j"));
-        Assert.assertTrue(mpqEditor.getListfileEntries().contains("war3map.w3u"));
         Assert.assertTrue(mpqEditor.getListfileEntries().contains("war3map.w3a"));
-        Assert.assertTrue(mpqEditor.getListfileEntries().contains("customFile.j"));
     }
 
     @Test

--- a/src/test/resources/listfile.txt
+++ b/src/test/resources/listfile.txt
@@ -1,0 +1,6 @@
+scripts\war3map.j
+war3map.j
+war3map.w3u
+war3map.w3t
+war3map.w3a
+customFile.j


### PR DESCRIPTION
- By calling the addExternalListfile method, allows JMPQ3 to write archives that were missing (listfile)
- Refactored code that was going to be common between the addExternalListfile method and the internal readListfile